### PR TITLE
Add a Dockerfile and Docker-Compose configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM perl:5
+RUN cpan App::cpanminus
+RUN cpanm LWP::UserAgent MIME::Base64 JSON Config::Tiny Benchmark Scalar::Util LWP::Protocol::https
+RUN apt-get update\
+    && apt-get install -y cron\
+    && rm -rf /var/lib/apt/lists/*
+ADD graphite-collector /opt/netapp/E-Series-Graphite-Grafana/
+
+RUN (crontab -l ; echo "* * * * * /usr/local/bin/perl /opt/netapp/E-Series-Graphite-Grafana/eseries-metrics-collector.pl -dc\
+ /opt/netapp/E-Series-Graphite-Grafana/api-config.conf >> /var/log/metrics.log 2>&1") | crontab
+RUN touch /var/log/metrics.log
+
+CMD ["cron", "-f"]

--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ the following snippet:
     root        = storage.eseries
     timeout     = 5
 
+
+Docker
+--------------------------------------------------------------------------------
+A Dockerfile and Docker-Compose file are available for simple deployment and/or trying out the functionality.
+
+The Dockerfile is intended to be a simple deployment of this project only, and is most useful if you
+already have Graphite and Grafana installed separately. If neither are currently installed/running, the
+docker-compose.yml file will define a test configuration for you that will start all three.
+
+It will be necessary for you to modify the graphite-collector/api-config.conf file with details on your
+environment, including the location and credentials of the WebServices Proxy, etc.
+
+Grafana will not load the dashboards provided in grafana-dashboards by default. These may be imported
+into the running Grafana instance. They will be persisted by default in a mount Docker host volume.
+
 BUGS
 --------------------------------------------------------------------------------
 Please report them [here](https://github.com/plz/E-Series-Graphite-Grafana/issues)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+###
+#  Running this Docker configuration will start a simple deployment of Graphite+Grafana and then
+# initiate a 3rd container (defined by the Dockerfile), that will, by default, collect statistics
+# from the configured Proxy (graphite-collector/api-config.conf), every minute.
+#
+#  This is not intended to be a production-ready deployment, but improvements are welcome/desired.
+###
+version: '2'
+services:
+  monitor:
+    build: .
+    image: eseries-graphite-grafana
+    depends_on:
+      - graphite
+      - grafana
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - .grafana/lib:/var/lib/grafana
+    depends_on:
+      - graphite
+  graphite:
+    image: hopsoft/graphite-statsd
+    ports:
+      - "8080:80"
+      - "2003-2004:2003-2004"
+      - "2023-2024:2023-2024"
+      - "8125:8125/udp"
+      - "8126:8126"
+    volumes:
+      # NOTE: If the graphite configuration is changed, it may be necessary to wipe out the existing collections
+      - .db-data:/opt/graphite/storage/whisper

--- a/graphite-collector/api-config.conf
+++ b/graphite-collector/api-config.conf
@@ -27,8 +27,9 @@ password    = XXXXXXXXXXXXXXX
 ### Graphite Details
 ###
 [graphite]
-server      = localhost
-port        = 3002
+# The hostname or IP address of the server
+server      = graphite
+port        = 2003
 proto       = tcp
 root        = storage.eseries
 timeout     = 5


### PR DESCRIPTION
Define a simple environment for running Graphite and collecting
E-Series statistics to display in Grafana.